### PR TITLE
Fix `six` import

### DIFF
--- a/jsonfield/encoder.py
+++ b/jsonfield/encoder.py
@@ -1,10 +1,11 @@
 from django.db.models.query import QuerySet
-from django.utils import six, timezone
+from django.utils import timezone
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
 import datetime
 import decimal
 import json
+import six
 import uuid
 
 

--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -1,10 +1,8 @@
 import copy
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-try:
-    from django.utils import six
-except ImportError:
-    import six
+
+import six
 
 try:
     import json


### PR DESCRIPTION
Removed the `from django.utils import six` import since it was removed
in Django 3.