### PR TITLE
[INT-1472] Update library for compatibility with Django 4.2

### DIFF
--- a/jsonfield/encoder.py
+++ b/jsonfield/encoder.py
@@ -1,6 +1,6 @@
 from django.db.models.query import QuerySet
 from django.utils import timezone
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import Promise
 import datetime
 import decimal
@@ -20,7 +20,7 @@ class JSONEncoder(json.JSONEncoder):
         # For Date Time string spec, see ECMA 262
         # http://ecma-international.org/ecma-262/5.1/#sec-15.9.1.15
         if isinstance(obj, Promise):
-            return force_text(obj)
+            return force_str(obj)
         elif isinstance(obj, datetime.datetime):
             representation = obj.isoformat()
             if obj.microsecond:

--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -1,6 +1,6 @@
 import copy
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 import six
 


### PR DESCRIPTION
## Jira Issue
[Update `django-jsonfield` fork to be compatible with Django 4.2](https://procurifyteam.atlassian.net/browse/INT-1472)

## Description
Removed deprecated usages of `force_text` and `ugettext_lazy` from the code so that the library will be compatible with Django 4.2.